### PR TITLE
update snappy to 1.1.10 + compilation patch

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -17,7 +17,6 @@ EOF
 
 git clone --recurse-submodules -b 1.1.10 https://github.com/google/snappy.git
 cd snappy
-git cherry-pick 27f34a580be4a3becf5f8c0cba13433f53c21337
 git apply ${BUILD_DIR}/../../snappy.patch
 cmake ${CMAKE_OPTIONS:-} .
 make snappy

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -15,8 +15,9 @@ cat <<EOF
 ************************************
 EOF
 
-git clone --recurse-submodules -b 1.1.9 https://github.com/google/snappy.git
+git clone --recurse-submodules -b 1.1.10 https://github.com/google/snappy.git
 cd snappy
+git cherry-pick 27f34a580be4a3becf5f8c0cba13433f53c21337
 git apply ${BUILD_DIR}/../../snappy.patch
 cmake ${CMAKE_OPTIONS:-} .
 make snappy

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -16,7 +16,6 @@ EOF
 
 git clone --recurse-submodules -b 1.1.10 https://github.com/google/snappy.git
 cd snappy
-git cherry-pick 27f34a580be4a3becf5f8c0cba13433f53c21337
 git apply ${BUILD_DIR}/../../snappy.patch
 cmake ${CMAKE_OPTIONS:-} .
 make snappy

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -14,8 +14,9 @@ cat <<EOF
 ************************************
 EOF
 
-git clone --recurse-submodules -b 1.1.9 https://github.com/google/snappy.git
+git clone --recurse-submodules -b 1.1.10 https://github.com/google/snappy.git
 cd snappy
+git cherry-pick 27f34a580be4a3becf5f8c0cba13433f53c21337
 git apply ${BUILD_DIR}/../../snappy.patch
 cmake ${CMAKE_OPTIONS:-} .
 make snappy

--- a/snappy.patch
+++ b/snappy.patch
@@ -10,3 +10,16 @@ index 68686f7..e360486 100644
  set_target_properties(snappy
    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
  
+diff --git a/snappy.cc b/snappy.cc
+index d414718..d0cbe54 100644
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1290,7 +1290,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
+         DeferMemCopy(&deferred_src, &deferred_length, from, len);
+       }
+     } while (ip < ip_limit_min_slop &&
+-             (op + deferred_length) < op_limit_min_slop);
++             static_cast<ptrdiff_t>(op + deferred_length) < op_limit_min_slop);
+   exit:
+     ip--;
+     assert(ip <= ip_limit);


### PR DESCRIPTION
snappy 1.1.10 plus this compilation patch https://github.com/google/snappy/commit/27f34a580be4a3becf5f8c0cba13433f53c21337

to try to fix integration tests which are failing similarly to https://github.com/apache/kvrocks/issues/788