### PR TITLE
Lower down glibc version requirements by compiling on ubuntu focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   linux_executor:
     docker:
-      - image: eclipse-temurin:17.0.8.1_1-jdk
+      - image: eclipse-temurin:17.0.8.1_1-jdk-focal
         auth:
           username: $DOCKER_USER_RO
           password: $DOCKER_PASSWORD_RO


### PR DESCRIPTION
`0.2.0` requires:
```
./libleveldbjni.so:
  libgcc_s.so.1 (GCC_3.0) => /lib/x86_64-linux-gnu/libgcc_s.so.1
  libc.so.6 (GLIBC_2.14) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libc.so.6
  libstdc++.so.6 (CXXABI_1.3.8) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (CXXABI_1.3.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.11) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (CXXABI_1.3) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.22) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.21) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4) => /lib/x86_64-linux-gnu/libstdc++.so.6
  /lib/x86_64-linux-gnu/libstdc++.so.6:
```

`0.3.0` requires:
```
./libleveldbjni.so:
  libgcc_s.so.1 (GCC_3.0) => /lib/x86_64-linux-gnu/libgcc_s.so.1
  libc.so.6 (GLIBC_2.4) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.33) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.14) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.3.4) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.34) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libc.so.6
  libstdc++.so.6 (CXXABI_1.3.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.29) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.11) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.22) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (CXXABI_1.3) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.30) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.21) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4) => /lib/x86_64-linux-gnu/libstdc++.so.6
```

`this` version (`0.3.1`?):
```
./libleveldbjni.so:
  libgcc_s.so.1 (GCC_3.0) => /lib/x86_64-linux-gnu/libgcc_s.so.1
  libc.so.6 (GLIBC_2.4) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.14) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.3.4) => /lib/x86_64-linux-gnu/libc.so.6
  libc.so.6 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libc.so.6
  libstdc++.so.6 (CXXABI_1.3.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.9) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (CXXABI_1.3) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.11) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.22) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4.21) => /lib/x86_64-linux-gnu/libstdc++.so.6
  libstdc++.so.6 (GLIBCXX_3.4) => /lib/x86_64-linux-gnu/libstdc++.so.6
```

Tested on `ubuntu:jammy` and `debian:11` docker images